### PR TITLE
Specify number of goroutines as proportion of CPUs

### DIFF
--- a/parallel/parallel.go
+++ b/parallel/parallel.go
@@ -1,7 +1,5 @@
 package parallel
 
-import "runtime"
-
 // For executes a loop in parallel from i = 0 while i < N
 func For(N int, loopBody func(i int)) {
 	DefaultStrategy().For(N, loopBody)
@@ -26,5 +24,5 @@ func WithCPUProportion(p float64) *Strategy {
 
 // DefaultNumGoroutines returns the default number of goroutines.
 func DefaultNumGoroutines() int {
-	return runtime.GOMAXPROCS(0)
+	return DefaultStrategy().NumGoroutines()
 }

--- a/parallel/parallel.go
+++ b/parallel/parallel.go
@@ -12,9 +12,16 @@ func ForWithGrID(N int, loopBody func(i, grID int)) {
 	DefaultStrategy().ForWithGrID(N, loopBody)
 }
 
-// WithNumGoroutines returns a default strategy, but using the specifiec number of goroutines.
+// WithNumGoroutines returns a default strategy,
+// but using the specifiec number of goroutines.
 func WithNumGoroutines(n int) *Strategy {
 	return DefaultStrategy().WithNumGoroutines(n)
+}
+
+// WithCPUProportion returns a default strategy,
+// but with the number of goroutines based on a proportion of number of CPUs
+func WithCPUProportion(p float64) *Strategy {
+	return DefaultStrategy().WithCPUProportion(p)
 }
 
 // DefaultNumGoroutines returns the default number of goroutines.

--- a/parallel/strategy.go
+++ b/parallel/strategy.go
@@ -1,6 +1,8 @@
 package parallel
 
 import (
+	"math"
+	"runtime"
 	"sync"
 )
 
@@ -26,6 +28,14 @@ func DefaultStrategy() *Strategy {
 // WithNumGoroutines sets the number of goroutines for a parallel strategy
 func (s *Strategy) WithNumGoroutines(numGoroutines int) *Strategy {
 	s.numGoroutines = numGoroutines
+	return s
+}
+
+// WithCPUProportion sets the number of goroutines based on a proportion of number of CPUs
+func (s *Strategy) WithCPUProportion(p float64) *Strategy {
+	numCPU := runtime.NumCPU()
+	pCPU := p * float64(numCPU)
+	s.numGoroutines = int(math.Max(pCPU, 1.0))
 	return s
 }
 

--- a/parallel/strategy.go
+++ b/parallel/strategy.go
@@ -21,8 +21,13 @@ func NewStrategy() *Strategy {
 // DefaultStrategy returns the default parallel strategy
 func DefaultStrategy() *Strategy {
 	s := new(Strategy)
-	s.numGoroutines = DefaultNumGoroutines()
+	s.numGoroutines = runtime.GOMAXPROCS(0)
 	return s
+}
+
+// NumGoroutines returns the number of goroutines that a strategy will use
+func (s *Strategy) NumGoroutines() int {
+	return s.numGoroutines
 }
 
 // WithNumGoroutines sets the number of goroutines for a parallel strategy

--- a/parallel/strategy_test.go
+++ b/parallel/strategy_test.go
@@ -79,6 +79,21 @@ func Test_StrategyForWithGrID_ComputesCorrectResult(t *testing.T) {
 	}
 }
 
+func Test_StrategyWithCPUProportion_HasAtLeastOneGoroutine(t *testing.T) {
+	// arrange
+	p := 0.0
+	expected := 1
+
+	// arrange / act
+	s := NewStrategy().WithCPUProportion(p)
+
+	// assert
+	actual := s.numGoroutines
+	if expected != actual {
+		t.Errorf("expected %d, actual %d\n", expected, actual)
+	}
+}
+
 func Test_StrategyGRIndexBlock_ReturnsCorrectRange(t *testing.T) {
 	type TestCase struct {
 		numGR, grID, N      int

--- a/parallel/strategy_test.go
+++ b/parallel/strategy_test.go
@@ -94,6 +94,20 @@ func Test_StrategyWithCPUProportion_HasAtLeastOneGoroutine(t *testing.T) {
 	}
 }
 
+func Test_StrategyNumGoroutines_ReturnsExpectedResult(t *testing.T) {
+	// arrange
+	expected := 3
+	s := DefaultStrategy().WithNumGoroutines(expected)
+
+	// act
+	actual := s.NumGoroutines()
+
+	// assert
+	if expected != actual {
+		t.Errorf("expected %d, actual %d\n", expected, actual)
+	}
+}
+
 func Test_StrategyGRIndexBlock_ReturnsCorrectRange(t *testing.T) {
 	type TestCase struct {
 		numGR, grID, N      int


### PR DESCRIPTION
* allows for num goroutines to be computed as a proportion of `runtime.NumCPU()`
* minimum of 1